### PR TITLE
Remove sourcemap

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,23 +1,23 @@
- const resolve = require('@rollup/plugin-node-resolve').default;
- const terser = require('rollup-plugin-terser').terser;
- const pkg = require('./package.json');
- 
- const banner = `/*!
+const resolve = require('@rollup/plugin-node-resolve').default;
+const terser = require('rollup-plugin-terser').terser;
+const pkg = require('./package.json');
+
+const banner = `/*!
   * ${pkg.name} v${pkg.version}
   * ${pkg.homepage}
   * (c) ${new Date().getFullYear()} chartjs-adapter-moment Contributors
   * Released under the ${pkg.license} license
   */`;
- 
- const input = 'src/index.js';
- const external = [
-   'chart.js',
-   'moment'
- ];
- const globals = {
-   'chart.js': 'Chart',
-   moment: 'moment'
- };
+
+const input = 'src/index.js';
+const external = [
+  'chart.js',
+  'moment'
+];
+const globals = {
+  'chart.js': 'Chart',
+  moment: 'moment'
+};
 
 module.exports = [
   {
@@ -49,7 +49,6 @@ module.exports = [
       name: pkg.name,
       file: pkg.main.replace('.js', '.min.js'),
       format: 'umd',
-      sourcemap: true,
       indent: false,
       globals
     },


### PR DESCRIPTION
Prevent (cosmetic) errors like:

> DevTools failed to load SourceMap: Could not load content for https://cdn.jsdelivr.net/npm/chartjs-adapter-moment.min.js.map: HTTP error: status code 404, net::ERR_HTTP_RESPONSE_CODE_FAILURE